### PR TITLE
Move Start Wave button after stylesheet inputs

### DIFF
--- a/app/components/td-game/stylesheet/template.hbs
+++ b/app/components/td-game/stylesheet/template.hbs
@@ -19,14 +19,6 @@
     <span class="hide-inputs__text" {{action "toggleHideInputs"}}>hide tower inputs</span>
   </div>
 
-  {{#unless attrs.waveStarted}}
-    {{#if attrs.towersColliding}}
-      <button class="stylesheet__start-wave-button">Start Wave</button>
-    {{else}}
-      <button class="stylesheet__start-wave-button stylesheet__start-wave-button--active" {{action "startWave"}}>Start Wave</button>
-    {{/if}}
-  {{/unless}}
-
   {{#each attrs.towerGroups as |towerGroup|}}
     <li class="block__line block__brace-line">
       <span class="block__selector">.{{towerGroup.selector}}</span>
@@ -73,4 +65,12 @@
       {{/each}}
     {{/if}}
   {{/each}}
+
+  {{#unless attrs.waveStarted}}
+    {{#if attrs.towersColliding}}
+      <button class="stylesheet__start-wave-button">Start Wave</button>
+    {{else}}
+      <button class="stylesheet__start-wave-button stylesheet__start-wave-button--active" {{action "startWave"}}>Start Wave</button>
+    {{/if}}
+  {{/unless}}
 </div>


### PR DESCRIPTION
By placing the start wave button after the stylesheet inputs, one can tab from the last input to the Start Wave button and start the wave without the mouse.